### PR TITLE
feat(opts): Fix --config, fix --url required

### DIFF
--- a/ssltest/Args.py
+++ b/ssltest/Args.py
@@ -12,7 +12,7 @@ class Args:
         parser = argparse.ArgumentParser(add_help=False)
         required = parser.add_argument_group("required arguments")
         fix_config = parser.add_mutually_exclusive_group()
-        required.add_argument("-u", "--url", required=True, metavar="url")
+        required.add_argument("-u", "--url", metavar="url")
         parser.add_argument("-h", "--help", action="store_true", default=False)
         parser.add_argument(
             "-p", "--port", default=[443], type=int, nargs="+", metavar="port"

--- a/ssltest/ConfigSetup.py
+++ b/ssltest/ConfigSetup.py
@@ -1,5 +1,5 @@
 import logging
-from os import sep, mkdir
+from os import sep, mkdir, listdir
 from os.path import exists
 from pathlib import Path
 from shutil import copy
@@ -34,10 +34,14 @@ class ConfigSetup:
                 copy(config_file, config_destination)
 
     @classmethod
-    def get_config_location(cls):
+    def get_config_location(cls, file_name):
         """
         Get the config location
+
+        :param str file_name: File name
         """
-        if cls.custom_dir is None:
-            return cls.install_dir
-        return cls.custom_dir
+        if cls.custom_dir is not None:
+            opt_dir = listdir(cls.custom_dir)
+            if file_name in opt_dir:
+                return cls.custom_dir
+        return cls.install_dir

--- a/ssltest/core/Script.py
+++ b/ssltest/core/Script.py
@@ -76,7 +76,12 @@ def get_help():
                     "<file>",
                     "Change output to json format, if a file name is specified output is written to the given file",
                 ],
-                ["-c", "--config", "<dir>", "Custom config directory (absolute path)"],
+                [
+                    "-c",
+                    "--config",
+                    "<dir>",
+                    "Custom config directory (absolute path), not all config files need to be present",
+                ],
                 [
                     "-t",
                     "--test",
@@ -162,6 +167,9 @@ def custom_args_parse(args, parser):
     if len(sys.argv) == 1 or "-h" in sys.argv or "--help" in sys.argv:
         print_help()
         sys.exit(0)
+
+    if args.url is None:
+        parser.error("the following arguments are required: -u/--url")
 
     error_string = (
         "option {error_option} needs "

--- a/ssltest/core/utils.py
+++ b/ssltest/core/utils.py
@@ -16,7 +16,7 @@ def read_json(file_name):
     :return: Json data in python objects
     :rtype: dict
     """
-    root_dir = ConfigSetup.get_config_location()
+    root_dir = ConfigSetup.get_config_location(file_name)
     file_path = f"{root_dir}{sep}{file_name}"
     log.debug(f"Opening {file_path}")
     file = open(file_path, "r")


### PR DESCRIPTION
- Not all files need to be present in the `--config` directory
- Url opt isn't required if no arguments are present or `-h` is present